### PR TITLE
Fix JSONDeepEquals for underscore

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "async": "^1.5.2",
     "aws-sdk": "^2.2.32",
     "jayschema": "0.3.1",
-    "string-format": "^0.5.0"
+    "string-format": "^0.5.0",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "istanbul": "^0.4.0",

--- a/src/JSONDeepEquals.js
+++ b/src/JSONDeepEquals.js
@@ -1,24 +1,5 @@
+var _ = require('underscore');
+
 module.exports = function JSONDeepEquals(a, b) {
-  if (a == null || b == null) {
-    return a === b;
-  }
-  var ka = Object.keys(a).sort();
-  var kb = Object.keys(b).sort();
-  if (Object(a) !== a) {
-    return a === b;
-  }
-  if (Array.isArray(a) || Array.isArray(b)) {
-    return Array.isArray(b) && Array.isArray(a) &&
-      a.length === b.length && a.every(function(av, i) {
-        return JSONDeepEquals(av, b[i]);
-      });
-  }
-  return ka.length === kb.length && ka.every(function(k, i) {
-    var av = a[k];
-    var bv = b[kb[i]];
-    var type = typeof av;
-    return type === typeof bv && type === 'object'
-      ? JSONDeepEquals(av, bv)
-      : (av === bv || (type === 'number' && isNaN(av) && isNaN(bv)));
-  });
+  return _.isEqual(a, b);
 };


### PR DESCRIPTION
Hi,

I have the same bug of this issue https://github.com/andrew-templeton/cfn-lambda/issues/6
So I fix it using a fully tested library `underscore`.

I keep the JSONDeepEquals object to be sure underscore pass all the tests.

Thanks again for this project.
Mathieu
