### PR TITLE
make requires webpackable

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -1,14 +1,12 @@
-
 const archiver = require('archiver')
 const async = require('async')
 const AWS = require('aws-sdk')
-const fs = require('fs')
 const nanoArgv = require('nano-argv')
 const path = require('path')
 const stream = require('stream')
 
-const regions = require(path.resolve(__dirname, 'lib', 'lambda.regions.json'))
-const template = require(path.resolve(__dirname, 'lib', 'cfn-template.json'))
+const regions = require('./lib/lambda.regions.json')
+const template = require('./lib/cfn-template.json')
 
 const defaults = {
   account: null,
@@ -28,7 +26,7 @@ AWS.config.region = process.env.AWS_REGION || 'us-east-1'
 
 module.exports = CfnResourceDeploy
 
-if (!module.parent) {
+if (require.main === module) {
   defaults.logs = true
   const opts = nanoArgv(defaults)
   opts.regions = opts.regions.split(',')

--- a/index.js
+++ b/index.js
@@ -1,16 +1,11 @@
+var https = require('https');
+var url = require('url');
 
-var path = require('path');
-
-var ValidationCheck = require(path.resolve(__dirname,
-  'src', 'validationCheck'));
-var SDKAlias = require(path.resolve(__dirname,
-  'src', 'SDKAlias'));
-var JSONDeepEquals = require(path.resolve(__dirname,
-  'src', 'JSONDeepEquals'));
-var DefaultExpander = require(path.resolve(__dirname,
-  'src', 'DefaultExpander'));
-var Composite = require(path.resolve(__dirname,
-  'src', 'Composite'));
+var ValidationCheck = require('./src/validationCheck');
+var SDKAlias = require('./src/SDKAlias');
+var JSONDeepEquals = require('./src/JSONDeepEquals');
+var DefaultExpander = require('./src/DefaultExpander');
+var Composite = require('./src/Composite');
 
 CfnLambdaFactory.SDKAlias = SDKAlias;
 CfnLambdaFactory.ValidationCheck = ValidationCheck;
@@ -231,8 +226,6 @@ function CfnLambdaFactory(resourceDefinition) {
       
       console.log('RESPONSE: %j', response);
 
-      var https = require('https');
-      var url = require('url');
       console.log('REPLYING TO: %s', event.ResponseURL);
       var parsedUrl = url.parse(event.ResponseURL);
       var options = {
@@ -298,5 +291,4 @@ function getEnvironment(context) {
   };
 }
 
-module.exports.deploy = require(path.resolve(__dirname,
-  'deploy'));
+module.exports.deploy = require('./deploy');

--- a/src/validationCheck.js
+++ b/src/validationCheck.js
@@ -5,8 +5,7 @@ var fs = require('fs');
 var JaySchema = require('jayschema');
 var JSONSchema = new JaySchema();
 
-var metaschema = JSON.parse(fs.readFileSync(path.resolve(__dirname,
-  '..', 'lib', 'metaschema.json')).toString());
+var metaschema = require('../lib/metaschema.json');
 
 
 module.exports = function checkIfInvalid(params, validatorObject) {


### PR DESCRIPTION
It's common to webpack functions to use dependencies and keep minimal sized zips. This PR allows it (though webpack still shows warnings).

- use `require('./...)` instead of `require.resolve(__dirname, ...)`
- replace `fs` with `require` where possible
- use `require.main === module` instead of `!require.parent`