### PR TITLE
Added support for async functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,9 +16,65 @@ CfnLambdaFactory.Composite = Composite;
 CfnLambdaFactory.Module = Composite.Module;
 module.exports = CfnLambdaFactory;
 
+function ReplyAfterHandler(promise, reply) {
+  promise.then(function(response) {
+    var { PhysicalResourceId, FnGetAttrsDataObj } = response || {};
+    reply(null, PhysicalResourceId, FnGetAttrsDataObj);
+  }).catch(function(err) {
+    reply(err.message || 'Unknown error');
+  });
+};
+
 function CfnLambdaFactory(resourceDefinition) {
 
   return function CfnLambda(event, context) {
+
+    // support Async handler functions:
+
+    if(resourceDefinition.AsyncCreate) {
+      if(resourceDefinition.Create) {
+        console.log('WARNING: Both Create and AsyncCreate handlers defined. Ignoring AsnycCreate');
+      } else {
+        resourceDefinition.Create = function(CfnRequestParams, reply) {
+          return ReplyAfterHandler(
+            resourceDefinition.AsyncCreate(CfnRequestParams), reply
+          );
+        }
+      }
+    }
+    if(resourceDefinition.AsyncUpdate) {
+      if(resourceDefinition.Update) {
+        console.log('WARNING: Both Update and AsyncUpdate handlers defined. Ignoring AsyncUpdate');
+      } else {
+        resourceDefinition.Update = function(RequestPhysicalID, CfnRequestParams, OldCfnRequestParams, reply) {
+          return ReplyAfterHandler(
+            resourceDefinition.AsyncUpdate(RequestPhysicalID, CfnRequestParams, OldCfnRequestParams), reply
+          );
+        }
+      }
+    }
+    if(resourceDefinition.AsyncDelete) {
+      if(resourceDefinition.Delete) {
+        console.log('WARNING: Both Delete and AsyncDelete handlers defined. Ignoring AsyncDelete');
+      } else {
+        resourceDefinition.Delete = function(RequestPhysicalID, CfnRequestParams, reply) {
+          return ReplyAfterHandler(
+            resourceDefinition.AsyncDelete(RequestPhysicalID, CfnRequestParams), reply
+          );
+        }
+      }
+    }
+    if(resourceDefinition.AsyncNoUpdate) {
+      if(resourceDefinition.NoUpdate) {
+        console.log('WARNING: Both NoUpdate and AsyncNoUpdate handlers defined. Ignoring AsyncNoUpdate');
+      } else {
+        resourceDefinition.NoUpdate = function(PhysicalResourceId, CfnResourceProperties, reply) {
+          return ReplyAfterHandler(
+            resourceDefinition.AsyncNoUpdate(PhysicalResourceId, CfnResourceProperties), reply
+          );
+        }
+      }
+    }
 
     if (event && event.ResourceProperties) {
       delete event.ResourceProperties.ServiceToken;
@@ -46,7 +102,7 @@ function CfnLambdaFactory(resourceDefinition) {
         longRunningConf.PingInSeconds &&
         longRunningConf.MaxPings &&
         longRunningConf.LambdaApi &&
-        longRunningConf.Methods && 
+        longRunningConf.Methods &&
         'function' === typeof longRunningConf.Methods[RequestType]) {
           console.log('Long running configurations found, ' +
             'providing this callback instead of the normal reply ' +
@@ -144,7 +200,7 @@ function CfnLambdaFactory(resourceDefinition) {
         });
       }, resourceDefinition.LongRunning.PingInSeconds * 1000);
     };
-    
+
     var invalidation = ValidationCheck(Params, {
       Validate: resourceDefinition.Validate,
       Schema: resourceDefinition.Schema,
@@ -158,7 +214,7 @@ function CfnLambdaFactory(resourceDefinition) {
       }
       console.log('cfn-lambda: Found an invalidation.');
       return NormalReply(invalidation);
-    } 
+    }
     if (RequestType === 'Create') {
       console.log('cfn-lambda: Delegating to Create handler.');
       return resourceDefinition.Create(Params, replyOrLongRunning('Create'));
@@ -218,12 +274,12 @@ function CfnLambdaFactory(resourceDefinition) {
         });
       }
     }
-    
+
 
     function sendResponse(response) {
 
       var responseBody = JSON.stringify(response);
-      
+
       console.log('RESPONSE: %j', response);
 
       console.log('REPLYING TO: %s', event.ResponseURL);
@@ -251,14 +307,14 @@ function CfnLambdaFactory(resourceDefinition) {
           // noop
         });
         response.on('end', function() {
-          // Tell AWS Lambda that the function execution is done  
+          // Tell AWS Lambda that the function execution is done
           context.done();
         });
       });
 
       request.on('error', function(error) {
         console.log('sendResponse Error:\n', error);
-        // Tell AWS Lambda that the function execution is done  
+        // Tell AWS Lambda that the function execution is done
         context.done();
       });
 

--- a/test/asnyc.js
+++ b/test/asnyc.js
@@ -1,0 +1,276 @@
+
+var path = require('path');
+var assert = require('assert');
+
+var Server = require(path.resolve(__dirname, '..', 'test-helpers', 'https', 'server'));
+var ContextStub = require(path.resolve(__dirname, '..', 'test-helpers', 'context'));
+var CfnLambda = require(path.resolve(__dirname, '..', 'index'));
+
+describe('Async support', function() {
+  var expectedUrl = '/foo/bar/taco';
+  var expectedStackId = 'fakeStackId';
+  var expectedRequestId = 'fakeRequestId';
+  var expectedLogicalResourceId = 'MyTestResource';
+  function HollowCreateRequest() {
+    return {
+      RequestType: 'Create',
+      ResponseURL: 'https://localhost:13002' + expectedUrl,
+      StackId: expectedStackId,
+      RequestId: expectedRequestId,
+      ResourceType: 'Custom::TestResource',
+      LogicalResourceId: expectedLogicalResourceId,
+      ResourceProperties: {
+        Foo: 'Bar'
+      }
+    };
+  }
+  function HollowUpdateRequest() {
+    return {
+      RequestType: 'Update',
+      ResponseURL: 'https://localhost:13002' + expectedUrl,
+      StackId: expectedStackId,
+      RequestId: expectedRequestId,
+      ResourceType: 'Custom::TestResource',
+      LogicalResourceId: expectedLogicalResourceId,
+      PhysicalResourceId: 'someFakeId',
+      ResourceProperties: {
+        Foo: 'Bar'
+      },
+      OldResourceProperties: {
+        Foo: 'Boo'
+      }
+    };
+  }
+  function HollowDeleteRequest() {
+    return {
+      RequestType: 'Delete',
+      ResponseURL: 'https://localhost:13002' + expectedUrl,
+      StackId: expectedStackId,
+      RequestId: expectedRequestId,
+      ResourceType: 'Custom::TestResource',
+      LogicalResourceId: expectedLogicalResourceId,
+      PhysicalResourceId: 'someFakeId',
+      ResourceProperties: {
+        Foo: 'Bar'
+      }
+    };
+  }
+  function wait() {
+    return new Promise(function(resolve, reject) {
+      setTimeout(function() {
+        resolve();
+      }, 50);
+    });
+  }
+  it('Should send error.messge to CloudFormation', function(done) {
+    var CfnRequest = HollowCreateRequest();
+    var errorMessage = 'Worked, it did not';
+    var Lambda = CfnLambda({
+      AsyncCreate: async function() {
+        throw new Error(errorMessage);
+      }
+    });
+    Server.on(function() {
+      Lambda(CfnRequest, ContextStub);
+    }, function(cfnResponse) {
+      assert(cfnResponse.body.Status === 'FAILED', 'Failed but replied with SUCCESS status');
+      assert(cfnResponse.body.Reason === errorMessage, 'Error message doesnt match');
+      // test would fail after 2s timeout if reply() callback is never called
+      done();
+    });
+  });
+  it('Should reply to server with response values when using AsyncCreate', function(done) {
+    var CfnRequest = HollowCreateRequest();
+    var response = {
+      PhysicalResourceId: 'yopadope',
+      FnGetAttrsDataObj: {
+        MyObj: 'dopeayope'
+      }
+    };
+    var Lambda = CfnLambda({
+      AsyncCreate: async function(Params) {
+        assert(Params.Foo === 'Bar', 'ResourceProperty Foo doesnt match');
+        await wait();
+        return response;
+      }
+    });
+    Server.on(function() {
+      Lambda(CfnRequest, ContextStub);
+    }, function(cfnResponse) {
+      assert(cfnResponse.body.Status === 'SUCCESS', 'Did not reply with SUCCESS status');
+      assert(cfnResponse.body.PhysicalResourceId === response.PhysicalResourceId, 'PhysicalResourceId doesnt match');
+      assert(cfnResponse.body.Data.MyObj === response.FnGetAttrsDataObj.MyObj, 'FnGetAttrsDataObj doesnt match');
+      // test would fail after 2s timeout if reply() callback is never called
+      done();
+    });
+  });
+  it('Should reply to server with response values when using AsyncDelete', function(done) {
+    var CfnRequest = HollowDeleteRequest();
+    var response = {
+      PhysicalResourceId: 'yopadope',
+      FnGetAttrsDataObj: {
+        MyObj: 'dopeayope'
+      }
+    };
+    var Lambda = CfnLambda({
+      AsyncDelete: async function(PhysicalId, Params) {
+        assert(PhysicalId === 'someFakeId', 'PhysicalId doesnt match');
+        assert(Params.Foo === 'Bar', 'ResourceProperty Foo doesnt match');
+        await wait();
+        return response;
+      }
+    });
+    Server.on(function() {
+      Lambda(CfnRequest, ContextStub);
+    }, function(cfnResponse) {
+      assert(cfnResponse.body.Status === 'SUCCESS', 'Did not reply with SUCCESS status');
+      assert(cfnResponse.body.PhysicalResourceId === response.PhysicalResourceId, 'PhysicalResourceId doesnt match');
+      assert(cfnResponse.body.Data.MyObj === response.FnGetAttrsDataObj.MyObj, 'FnGetAttrsDataObj doesnt match');
+      // test would fail after 2s timeout if reply() callback is never called
+      done();
+    });
+  });
+  it('Should reply to server with response values when using AsyncUpdate', function(done) {
+    var CfnRequest = HollowUpdateRequest();
+    var response = {
+      PhysicalResourceId: 'yopadope',
+      FnGetAttrsDataObj: {
+        MyObj: 'dopeayope'
+      }
+    };
+    var Lambda = CfnLambda({
+      AsyncUpdate: async function(PhysicalId, Params, OldParams) {
+        assert(PhysicalId === 'someFakeId', 'PhysicalId doesnt match');
+        assert(Params.Foo === 'Bar', 'ResourceProperty Foo doesnt match');
+        assert(OldParams.Foo === 'Boo', 'OldResourceProperty Foo doesnt match');
+        await wait();
+        return response;
+      }
+    });
+    Server.on(function() {
+      Lambda(CfnRequest, ContextStub);
+    }, function(cfnResponse) {
+      assert(cfnResponse.body.Status === 'SUCCESS', 'Did not reply with SUCCESS status');
+      assert(cfnResponse.body.PhysicalResourceId === response.PhysicalResourceId, 'PhysicalResourceId doesnt match');
+      assert(cfnResponse.body.Data.MyObj === response.FnGetAttrsDataObj.MyObj, 'FnGetAttrsDataObj doesnt match');
+      // test would fail after 2s timeout if reply() callback is never called
+      done();
+    });
+  });
+  it('Should reply to server with response values when using AsyncNoUpdate', function(done) {
+    var CfnRequest = HollowUpdateRequest();
+    CfnRequest.ResourceProperties = {
+      Foo: 'Boo' // Same value as OldResourceProperties
+    };
+    var response = {
+      PhysicalResourceId: 'yopadope',
+      FnGetAttrsDataObj: {
+        MyObj: 'dopeayope'
+      }
+    };
+    var Lambda = CfnLambda({
+      AsyncNoUpdate: async function(PhysicalId, Params) {
+        assert(PhysicalId === 'someFakeId', 'PhysicalId doesnt match');
+        assert(Params.Foo === 'Boo', 'ResourceProperty Foo doesnt match');
+        await wait();
+        return response;
+      }
+    });
+    Server.on(function() {
+      Lambda(CfnRequest, ContextStub);
+    }, function(cfnResponse) {
+      assert(cfnResponse.body.Status === 'SUCCESS', 'Did not reply with SUCCESS status');
+      assert(cfnResponse.body.PhysicalResourceId === response.PhysicalResourceId, 'PhysicalResourceId doesnt match');
+      assert(cfnResponse.body.Data.MyObj === response.FnGetAttrsDataObj.MyObj, 'FnGetAttrsDataObj doesnt match');
+      // test would fail after 2s timeout if reply() callback is never called
+      done();
+    });
+  });
+  it('Should prioritize regular Create over AsyncCreate', function(done) {
+    var CfnRequest = HollowCreateRequest();
+    var asyncCalled = false;
+    var regularCalled = false;
+    var Lambda = CfnLambda({
+      AsyncCreate: function(Params) {
+        asyncCalled = true;
+      },
+      Create: function(Params, reply) {
+        regularCalled = true;
+        reply();
+      }
+    });
+    Server.on(function() {
+      Lambda(CfnRequest, ContextStub);
+    }, function(cfnResponse) {
+      assert(asyncCalled === false, 'Should not call async version');
+      assert(regularCalled === true, 'Should call regular version');
+      done();
+    });
+  });
+  it('Should prioritize regular Delete over AsyncDelete', function(done) {
+    var CfnRequest = HollowDeleteRequest();
+    var asyncCalled = false;
+    var regularCalled = false;
+    var Lambda = CfnLambda({
+      AsyncDelete: function(PhysicalId, Params) {
+        asyncCalled = true;
+      },
+      Delete: function(PhysicalId, Params, reply) {
+        regularCalled = true;
+        reply();
+      }
+    });
+    Server.on(function() {
+      Lambda(CfnRequest, ContextStub);
+    }, function(cfnResponse) {
+      assert(asyncCalled === false, 'Should not call async version');
+      assert(regularCalled === true, 'Should call regular version');
+      done();
+    });
+  });
+  it('Should prioritize regular Update over AsyncUpdate', function(done) {
+    var CfnRequest = HollowUpdateRequest();
+    var asyncCalled = false;
+    var regularCalled = false;
+    var Lambda = CfnLambda({
+      AsyncUpdate: function(PhysicalId, Params, OldParams) {
+        asyncCalled = true;
+      },
+      Update: function(PhysicalId, Params, OldParams, reply) {
+        regularCalled = true;
+        reply();
+      }
+    });
+    Server.on(function() {
+      Lambda(CfnRequest, ContextStub);
+    }, function(cfnResponse) {
+      assert(asyncCalled === false, 'Should not call async version');
+      assert(regularCalled === true, 'Should call regular version');
+      done();
+    });
+  });
+  it('Should prioritize regular NoUpdate over AsyncNoUpdate', function(done) {
+    var CfnRequest = HollowUpdateRequest();
+    CfnRequest.ResourceProperties = {
+      Foo: 'Boo' // Same value as OldResourceProperties
+    };
+    var asyncCalled = false;
+    var regularCalled = false;
+    var Lambda = CfnLambda({
+      AsyncNoUpdate: function(PhysicalId, Params) {
+        asyncCalled = true;
+      },
+      NoUpdate: function(PhysicalId, Params, reply) {
+        regularCalled = true;
+        reply();
+      }
+    });
+    Server.on(function() {
+      Lambda(CfnRequest, ContextStub);
+    }, function(cfnResponse) {
+      assert(asyncCalled === false, 'Should not call async version');
+      assert(regularCalled === true, 'Should call regular version');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Hello @andrew-templeton 

I noticed that if I were to mark my handler functions as async and then wait for a promise to resolve before calling the `reply()` callback, then the Lambda execution would actually stop before the S3 PUT request finishes. As I'm sure you know, the consequences of this are quite annoying to deal with. 

I have attempted to fix the issue by wrapping the async function into a normal function that uses `then` and `catch` to invoke the reply callback appropriately. From my testing so far it seems to be working. I also added a section to the docs explaining how to use this async function support feature.

Thank you very much for this repository ! It was very useful to me while developing a project of my own with custom resources. Once I put my project up on Github, I hope you would consider adding me to the list of source code examples in the README.

:smile: 