### PR TITLE
Feat: add ability to pass NoEcho to response object

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,9 @@ exports.handler = CfnLambda({
   NoUpdate: NoUpdate, // Optional
   TriggersReplacement: TriggersReplacement, // Array<String> of properties forcing Replacement
 
-  LongRunning: <see Long Running below> // Optional. Configure a lambda to last beyond 5 minutes.
+  NoEcho: true, // Optional, default is false. Masks the 'Data' Response property. See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources.html for more information.
 
+  LongRunning: <see Long Running below> // Optional. Configure a lambda to last beyond 5 minutes.
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -259,7 +259,8 @@ function CfnLambdaFactory(resourceDefinition) {
             StackId: event.StackId,
             RequestId: event.RequestId,
             LogicalResourceId: event.LogicalResourceId,
-            Data: optionalData
+            Data: optionalData,
+            NoEcho: resourceDefinition.NoEcho || false
           });
         }
         return functor({
@@ -270,7 +271,8 @@ function CfnLambdaFactory(resourceDefinition) {
           StackId: event.StackId,
           RequestId: event.RequestId,
           LogicalResourceId: event.LogicalResourceId,
-          Data: optionalData || OldParams
+          Data: optionalData || OldParams,
+          NoEcho: resourceDefinition.NoEcho || false
         });
       }
     }

--- a/test-helpers/https/server.js
+++ b/test-helpers/https/server.js
@@ -41,5 +41,9 @@ module.exports = {
       callback();
     }
     return this;
+  },
+  close: function() {    
+    server.close();
+    this.listening = false;
   }
 };

--- a/test/async.js
+++ b/test/async.js
@@ -7,6 +7,11 @@ var ContextStub = require(path.resolve(__dirname, '..', 'test-helpers', 'context
 var CfnLambda = require(path.resolve(__dirname, '..', 'index'));
 
 describe('Async support', function() {
+
+  after(() => {
+    Server.close();
+  });
+  
   var expectedUrl = '/foo/bar/taco';
   var expectedStackId = 'fakeStackId';
   var expectedRequestId = 'fakeRequestId';

--- a/test/create.js
+++ b/test/create.js
@@ -9,6 +9,11 @@ var CfnLambda = require(path.resolve(__dirname, '..', 'index'));
 
 
 describe('Create', function() {
+
+  after(() => {
+    Server.close();
+  });
+
   var expectedUrl = '/foo/bar/taco';
   var expectedStackId = 'fakeStackId';
   var expectedRequestId = 'fakeRequestId';
@@ -205,5 +210,38 @@ describe('Create', function() {
       done();
     });
 
+  });
+
+  it('Should default NoEcho to false', function(done) {
+    var CfnRequest = HollowRequest();
+    var Lambda = CfnLambda({
+      Create: function(Params, reply) {
+        reply();
+      }
+    });
+
+    Server.on(function() {
+      Lambda(CfnRequest, ContextStub);
+    }, function(cfnResponse) {
+      assert(false === cfnResponse.body.NoEcho, 'Expected NoEcho to be false');     
+      done();
+    });
+  });
+
+  it('Should set NoEcho to true', function(done) {
+    var CfnRequest = HollowRequest();
+    var Lambda = CfnLambda({
+      Create: function(Params, reply) {
+        reply();
+      },
+      NoEcho: true
+    });
+
+    Server.on(function() {
+      Lambda(CfnRequest, ContextStub);
+    }, function(cfnResponse) {
+      assert(true === cfnResponse.body.NoEcho, 'Expected NoEcho to be true');     
+      done();
+    });
   });
 });

--- a/test/delete.js
+++ b/test/delete.js
@@ -9,6 +9,11 @@ var CfnLambda = require(path.resolve(__dirname, '..', 'index'));
 
 
 describe('Delete', function() {
+
+  after(() => {
+    Server.close();
+  });
+
   var expectedUrl = '/foo/bar/taco';
   var expectedStackId = 'fakeStackId';
   var expectedRequestId = 'fakeRequestId';
@@ -152,5 +157,38 @@ describe('Delete', function() {
       done();
     });
 
+  });
+
+  it('Should default NoEcho to false', function(done) {
+    var CfnRequest = HollowRequest();
+    var Lambda = CfnLambda({
+      Delete: function(PhysicalId, Params, reply) {
+        reply();
+      }
+    });
+
+    Server.on(function() {
+      Lambda(CfnRequest, ContextStub);
+    }, function(cfnResponse) {
+      assert(false === cfnResponse.body.NoEcho, 'Expected NoEcho to be false');     
+      done();
+    });
+  });
+
+  it('Should set NoEcho to true', function(done) {
+    var CfnRequest = HollowRequest();
+    var Lambda = CfnLambda({
+      Delete: function(PhysicalId, Params, reply) {
+        reply();
+      },
+      NoEcho: true
+    });
+
+    Server.on(function() {
+      Lambda(CfnRequest, ContextStub);
+    }, function(cfnResponse) {
+      assert(true === cfnResponse.body.NoEcho, 'Expected NoEcho to be true');     
+      done();
+    });
   });
 });

--- a/test/environment.js
+++ b/test/environment.js
@@ -10,6 +10,11 @@ var CfnLambda = require(path.resolve(__dirname, '..', 'index'));
 
 
 describe('CfnLambda#Environment', function() {
+  
+  after(() => {
+    Server.close();
+  });
+
   function HollowRequest() {
     return {
       RequestType: 'Create',

--- a/test/errors.js
+++ b/test/errors.js
@@ -9,6 +9,11 @@ var CfnLambda = require(path.resolve(__dirname, '..', 'index'));
 
 
 describe('Severe CloudFormation Errors', function() {
+
+  after(() => {
+    Server.close();
+  });
+
   it('should still terminate lambda on signed url connection errors', function(done) {
     var expectedUrl = '/foo/bar/taco';
     var expectedStackId = 'fakeStackId';

--- a/test/longRunning.js
+++ b/test/longRunning.js
@@ -11,6 +11,11 @@ var CfnLambda = require(path.resolve(__dirname, '..', 'index'));
 
 
 describe('LongRunning', function() {
+
+  after(() => {
+    Server.close();
+  });
+  
   var expectedUrl = '/foo/bar/taco';
   var expectedStackId = 'fakeStackId';
   var expectedRequestId = 'fakeRequestId';

--- a/test/update.js
+++ b/test/update.js
@@ -9,6 +9,11 @@ var CfnLambda = require(path.resolve(__dirname, '..', 'index'));
 
 
 describe('Update', function() {
+  
+  after(() => {
+    Server.close();
+  });
+
   var expectedUrl = '/foo/bar/taco';
   var expectedStackId = 'fakeStackId';
   var expectedRequestId = 'fakeRequestId';
@@ -317,5 +322,38 @@ describe('Update', function() {
       done();
     });
 
+  });
+
+  it('Should default NoEcho to false', function(done) {
+    var CfnRequest = HollowRequest();
+    var Lambda = CfnLambda({
+      Update: function(PhysicalId, Params, OldParams, reply) {
+        reply();
+      }
+    });
+
+    Server.on(function() {
+      Lambda(CfnRequest, ContextStub);
+    }, function(cfnResponse) {
+      assert(false === cfnResponse.body.NoEcho, 'Expected NoEcho to be false');     
+      done();
+    });
+  });
+
+  it('Should set NoEcho to true', function(done) {
+    var CfnRequest = HollowRequest();
+    var Lambda = CfnLambda({
+      Update: function(PhysicalId, Params, OldParams, reply) {
+        reply();
+      },
+      NoEcho: true
+    });
+
+    Server.on(function() {
+      Lambda(CfnRequest, ContextStub);
+    }, function(cfnResponse) {
+      assert(true === cfnResponse.body.NoEcho, 'Expected NoEcho to be true');     
+      done();
+    });
   });
 });


### PR DESCRIPTION
`NoEcho` can be used to mask the output of the custom resource.
See here: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources.html

I've also added some tests, and made sure to shutdown the http server at the end of the tests (otherwise the `npm test` command never exits).